### PR TITLE
Fix broken links

### DIFF
--- a/source/introduction/advantages.rst
+++ b/source/introduction/advantages.rst
@@ -47,4 +47,4 @@ Successful application projects run a lot of tests. Whereas some tests may be au
 
 The LibreOffice_ project, for example, uses AppImages to test new application versions.
 
-.. _LibreOffice: https://https://www.libreoffice.org/download/appimage/
+.. _LibreOffice: https://www.libreoffice.org/download/appimage/

--- a/source/introduction/concepts.rst
+++ b/source/introduction/concepts.rst
@@ -35,7 +35,7 @@ Applications should be built on the oldest possible system, allowing them to run
 
 It may seem contradictory to :ref:`the previous section <no-external-dependencies>` to rely on distribution provided resources. This is a trade-off between trying to reduce redundancies while at the same time being as self-contained as possible.
 
-In some cases, including the libraries might even break the AppImage on the target system. Those libraries involve, among others, hardware dependent libraries such as graphics card drivers provided libraries (e.g., :code:`libGL.so.1`, (`source <https://github.com/AppImage/AppImages/blob/14c255b528dd88ef3e00ae0446ac6d84a20ac798/excludelist#L38-L41>`_)), or libraries that are build and linked differently on different distributions (e.g., :code:`libharfbuzz.so.0` and :code:`libfreetype.so.6` (`source <https://github.com/AppImage/AppImages/blob/14c255b528dd88ef3e00ae0446ac6d84a20ac798/excludelist#L98-L102>`_).
+In some cases, including the libraries might even break the AppImage on the target system. Those libraries involve, among others, hardware dependent libraries such as graphics card drivers provided libraries (e.g., :code:`libGL.so.1`, (`source <https://github.com/AppImage/AppImages/blob/14c255b528dd88ef3e00ae0446ac6d84a20ac798/excludelist\#L38-L41>`_)), or libraries that are build and linked differently on different distributions (e.g., :code:`libharfbuzz.so.0` and :code:`libfreetype.so.6` (`source <https://github.com/AppImage/AppImages/blob/14c255b528dd88ef3e00ae0446ac6d84a20ac798/excludelist\#L98-L102>`_).
 
 The list of libraries that can resp. have to be excluded, the so-called :ref:`excludelist <excludelist>`, is carefully curated by the AppImage team, and is regularly updated.
 

--- a/source/introduction/software-overview.rst
+++ b/source/introduction/software-overview.rst
@@ -78,7 +78,7 @@ The project consists of two tools: :code:`appimageupdatetool`, a full-featured C
 
 .. _AppImageUpdate: https://github.com/AppImage/AppImageUpdate
 
-.. _update information: https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
+.. _update information: https://github.com/AppImage/AppImageSpec/blob/master/draft.md\#update-information
 
 
 .. _appimaged:
@@ -116,11 +116,11 @@ AppImageLauncher_ is a helper application for Linux distributions serving as a k
 Quoting the README:
 
     AppImageLauncher makes your Linux desktop AppImage ready™. By installing it, you won't ever have to worry about AppImages again. You can always double click them without making them executable first, just like you should be able to do nowadays. You can integrate AppImages with a single mouse click, and manage them from your application launcher. Updating and removing AppImages becomes as easy as never before.
-    
+
     Due to its simple but efficient way to integrate into your system, it plays well with other applications that can be used to manage AppImages, for example app stores. However, it doesn't depend on any of those, and can run completely standalone.
-    
+
     Install AppImageLauncher today for your distribution and enjoy using AppImages as easy as never before!
-    
+
     -- https://github.com/TheAssassin/AppImageLauncher/blob/master/README.md
 
 AppImageLauncher doesn't provide any kind of "app store" software, but integrates into system-provided launchers' context menus. It provides tools for updating (based on :ref:`AppImageUpdate`) and removing AppImages.


### PR DESCRIPTION
Fixed libreOffice link in introduction/advantages.rst
Escaped '#' in introduction/advantages.rst (Travis' `make linkcheck` was complaining about unresovable anchors)
Same as above with introduction/software-overview.rst
