### PR TITLE
Correct desktop entry's category per official "Registered Categories"

### DIFF
--- a/source/packaging-guide/manual.rst
+++ b/source/packaging-guide/manual.rst
@@ -78,7 +78,7 @@ myapp.desktop should contain (as a minimum):
 	Exec=myapp
 	Icon=myapp
 	Type=Application
-	Categories=Utilities;
+	Categories=Utility;
 
 Be sure to pick one of the `Registered Categories`_, and be sure that your desktop file passes validation by using :code:`desktop-file-validate your.desktop`. If you are not deploying an application with a graphical user interface (GUI) but a command line tool (for the terminal), make sure to add :code:`Terminal=true`.
 


### PR DESCRIPTION
Got this when trying to create an appimage from scratch, with an example .desktop file from this documentation:

    /home/fboender/py-appimage/app/blaat.desktop: error: value "Utilities;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Utilities"; values extending the format should start with "X-"
    ERROR: Desktop file contains errors. Please fix them. Please see
           https://standards.freedesktop.org/desktop-entry-spec/latest/

This pull request fixes the category.