### PR TITLE
Clarify that AppRun is not deprecated but is not used e.g., by linuxdeploy

### DIFF
--- a/source/introduction/software-overview.rst
+++ b/source/introduction/software-overview.rst
@@ -51,7 +51,7 @@ In some cases, though, when an existing application must not be altered (e.g., w
 Using :code:`AppRun` is not a guarantee that an application will run, and the packager must provide all the resources an application could need manually (or by using external tools) before creating the AppImage with :ref:`appimagetool`. :code:`AppRun` force-changes the current working directory, and therefore applications can not detect where the AppImage was called originally. This may be especially annoying for CLI tools, but can also be a problem for GUI applications expecting paths via parameters.
 
 .. note::
-   :code:`AppRun` is legacy technology, and should be avoided if possible. Tools like :ref:`linuxdeploy` deploy applications in a different way, and deprecated its usage. This doesn't mean there's no cases in which :code:`AppRun` might be useful, but it's got several limitations a user must be aware of before using it.
+   An :code:`AppRun` binary or script may not be needed in some cases, and a symlink with the same name to the main binary may be sufficient instead. Tools like :ref:`linuxdeploy` deploy applications in a different way.
 
 **Download:** There is usually no reason to download this manually, but if you still want to, you can get it from https://github.com/AppImage/AppImageKit/releases/continuous.
 

--- a/source/introduction/software-overview.rst
+++ b/source/introduction/software-overview.rst
@@ -39,6 +39,7 @@ appimagetool implements all optional features, like for instance :ref:`update in
 
 **Download:** You can get it as an AppImage from https://github.com/AppImage/AppImageKit/releases/continuous. 
 
+
 AppRun
 ^^^^^^
 
@@ -46,12 +47,14 @@ Every AppImage's AppDir must contain a file called :code:`AppRun`, providing the
 
 :code:`AppRun` doesn't necessarily have to be a regular file. If the application is :ref:`relocatable <relocatable-apps>`, it can just be a symlink to the main binary. Tools like :ref:`linuxdeploy` can turn applications into relocatable applications, and therefore create such a symlink.
 
-In some cases, though, when an existing application must not be altered (e.g., when the license prohibits any modifications) or tools like linuxdeploy cannot be used, :code:`AppRun.c` can be used. :code:`AppRun.c` attempts to make programs load bundled shared libraries instead of system ones by manipulating environment variable. Furthermore, it attempts to prevent warnings users might encounter that are coming from the fact the :ref:`AppDir` is mounted read-only.
+In some cases, though, when an existing application must not be altered (e.g., when the license prohibits any modifications) or tools like linuxdeploy cannot be used, AppImageKit's :code:`AppRun.c` can be used. :code:`AppRun.c` attempts to make programs load bundled shared libraries instead of system ones by manipulating environment variable. Furthermore, it attempts to prevent warnings users might encounter that are coming from the fact the :ref:`AppDir` is mounted read-only.
 
-Using :code:`AppRun` is not a guarantee that an application will run, and the packager must provide all the resources an application could need manually (or by using external tools) before creating the AppImage with :ref:`appimagetool`. :code:`AppRun` force-changes the current working directory, and therefore applications can not detect where the AppImage was called originally. This may be especially annoying for CLI tools, but can also be a problem for GUI applications expecting paths via parameters.
+Using :code:`AppRun.c` is not a guarantee that an application will run, and the packager must provide all the resources an application could need manually (or by using external tools) before creating the AppImage with :ref:`appimagetool`. :code:`AppRun` force-changes the current working directory, and therefore applications can not detect where the AppImage was called originally. This may be especially annoying for CLI tools, but can also be a problem for GUI applications expecting paths via parameters.
 
 .. note::
-   An :code:`AppRun` binary or script may not be needed in some cases, and a symlink with the same name to the main binary may be sufficient instead. Tools like :ref:`linuxdeploy` deploy applications in a different way.
+   :code:`AppRun.c`, the binary from AppImageKit, is legacy technology and should be avoided if possible. Tools like :ref:`linuxdeploy` deploy applications in a different way (they are smart enough so that a simple symlink called :code:`AppRun` to the main binary works just fine), and made using :code:`AppRun.c` obsolete in most cases.
+
+   There are some edge cases where :code:`AppRun.c` is still in use, and there it might be useful. However, it suffers from many limitations and requires some workarounds (which require troublesome mechanisms, such as e.g., force-changing current working directory, as described in this section), which can cause a lot of trouble while trying to debug an AppImage. Please beware of these before thinking about using :code:`AppRun.c` in your AppImage.
 
 **Download:** There is usually no reason to download this manually, but if you still want to, you can get it from https://github.com/AppImage/AppImageKit/releases/continuous.
 


### PR DESCRIPTION
To prevent misunderstandings like https://twitter.com/whitequark/status/1166589229939527681