### PR TITLE
Update for Ubuntu 22.04 / fuse3

### DIFF
--- a/source/user-guide/troubleshooting/fuse.rst
+++ b/source/user-guide/troubleshooting/fuse.rst
@@ -43,15 +43,16 @@ The process of installing FUSE highly differs from distribution to distribution.
    If your distribution is not listed, please ask the distribution developers for instructions.
 
 
+.. _ref-ug-troubleshooting-fuse-fuse2:
+
 Setting up FUSE 2.x on Ubuntu (pre-22.04), Debian and their derivatives
 ***********************************************************************
 
 .. warning::
-    This is valid only for distributions **not having** ``fuse3`` installed by default.  
-    
-    To be sure, enter ``dpkg -l|grep fuse3``  
-    
-    If you see a line starting with ``ii  fuse3``, please refer to the next section.
+
+   This is valid only for distributions *not* having ``fuse3`` installed by default. To be sure, check whether the :code:`fuse3` package is installed, e.g., by running :code:`dpkg -l | grep fuse3` in the terminal and checking for a line starting with :code:`ii  fuse3`.
+
+   If your distribution is using :code:`fuse3`, please refer to the :ref:`next section <ref-ug-troubleshooting-fuse-fuse3>`.
 
 Install the required packages::
 
@@ -70,15 +71,17 @@ Then, add the required group (should be created by the install command, if this 
 
 .. include:: notes/user-group-modifications.rst
 
+
+.. _ref-ug-troubleshooting-fuse-fuse3:
+
 Setting up FUSE 2.x alongside of FUSE 3.x on recent Ubuntu (>=22.04), Debian and their derivatives 
 **************************************************************************************************
 
 .. warning::
-    This is valid only for recent distributions **having** ``fuse3`` installed by default.  
-    
-    To be sure, enter ``dpkg -l|grep fuse3``  
-    
-    If you see a line starting with ``ii  fuse3``, be sure **not to install** the ``fuse`` package which would remove packages very important for your system.  
+
+   This is valid only for very recent (as of April 2022) distributions having :code:`fuse3` installed by default. To be sure, check whether the :code:`fuse3` package is installed, e.g., by running :code:`dpkg -l | grep fuse3` in the terminal and checking for a line starting with :code:`ii  fuse3` (if there is none, your distribution is not using :code:`fuse3`).
+
+   If your distribution is not using :code:`fuse3`, please refer to the :ref:`previous section <ref-ug-troubleshooting-fuse-fuse2>`.
 
 Install the required package::
 

--- a/source/user-guide/troubleshooting/fuse.rst
+++ b/source/user-guide/troubleshooting/fuse.rst
@@ -47,11 +47,11 @@ Setting up FUSE 2.x on Ubuntu (pre-22.04), Debian and their derivatives
 ***********************************************************************
 
 .. warning::
-    This is valid only for distributions **not having** `fuse3` installed by default.  
+    This is valid only for distributions **not having** ``fuse3`` installed by default.  
     
-    To be sure, enter `dpkg -l|grep fuse3`  
+    To be sure, enter ``dpkg -l|grep fuse3``  
     
-    If you see a line starting with `ii  fuse3`, please refer to the next section.
+    If you see a line starting with ``ii  fuse3``, please refer to the next section.
 
 Install the required packages::
 
@@ -74,11 +74,11 @@ Setting up FUSE 2.x alongside of FUSE 3.x on recent Ubuntu (>=22.04), Debian and
 **************************************************************************************************
 
 .. warning::
-    This is valid only for recent distributions **having** `fuse3` installed by default.  
+    This is valid only for recent distributions **having** ``fuse3`` installed by default.  
     
-    To be sure, enter `dpkg -l|grep fuse3`  
+    To be sure, enter ``dpkg -l|grep fuse3``  
     
-    If you see a line starting with `ii  fuse3`, be sure **not to install** the `fuse` package which would remove packages very important for your system.  
+    If you see a line starting with ``ii  fuse3``, be sure **not to install** the ``fuse`` package which would remove packages very important for your system.  
 
 Install the required package::
 

--- a/source/user-guide/troubleshooting/fuse.rst
+++ b/source/user-guide/troubleshooting/fuse.rst
@@ -43,10 +43,17 @@ The process of installing FUSE highly differs from distribution to distribution.
    If your distribution is not listed, please ask the distribution developers for instructions.
 
 
-Setting up FUSE 2.x on Ubuntu, Debian and their derivatives
-***********************************************************
+Setting up FUSE 2.x on Ubuntu (pre-22.04), Debian and their derivatives
+***********************************************************************
 
-Install the required package::
+.. warning::
+    This is valid only for distributions **not having** `fuse3` installed by default.  
+    
+    To be sure, enter `dpkg -l|grep fuse3`  
+    
+    If you see a line starting with `ii  fuse3`, please refer to the next section.
+
+Install the required packages::
 
   > sudo apt-get install fuse libfuse2
 
@@ -63,6 +70,21 @@ Then, add the required group (should be created by the install command, if this 
 
 .. include:: notes/user-group-modifications.rst
 
+Setting up FUSE 2.x alongside of FUSE 3.x on recent Ubuntu (>=22.04), Debian and their derivatives 
+**************************************************************************************************
+
+.. warning::
+    This is valid only for recent distributions **having** `fuse3` installed by default.  
+    
+    To be sure, enter `dpkg -l|grep fuse3`  
+    
+    If you see a line starting with `ii  fuse3`, be sure **not to install** the `fuse` package which would remove packages very important for your system.  
+
+Install the required package::
+
+  > sudo apt install libfuse2
+
+Now, FUSE 2.x should be working alongside of FUSE 3.x without breaking your system.
 
 Setting up FUSE 2.x on openSUSE
 *******************************


### PR DESCRIPTION
The package fuse must not be installed if the package fuse3 is already installed, it would lead to removal of system packages