### PR TITLE
Correct Arch Linux FUSE troubleshooting info

### DIFF
--- a/source/user-guide/troubleshooting/fuse.rst
+++ b/source/user-guide/troubleshooting/fuse.rst
@@ -152,7 +152,13 @@ FUSE is not operational out of the box. However, starting with release 73, it's 
 Setting up FUSE on Arch Linux
 *****************************
 
-On Arch Linux, FUSE should work already. A common issue, however, is that the ``fusermount`` binary's permissions may be incorrect. Fortunately, there's an easy fix:
+Install the required package:
+
+.. code-block:: shell
+
+   sudo pacman -S fuse2
+
+A common issue, however, is that the ``fusermount`` binary's permissions may be incorrect. Fortunately, there's an easy fix:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Current Arch Linux FUSE troubleshooting info is wrong. `fuse2` is not a mandatory package and may not be present in the system.

Fixes #72