### PR TITLE
docs: update Ubuntu info for electron sandboxing

### DIFF
--- a/source/user-guide/troubleshooting/electron-sandboxing.rst
+++ b/source/user-guide/troubleshooting/electron-sandboxing.rst
@@ -3,7 +3,7 @@
 I have issues with Electron-based AppImages and their sandboxing
 ================================================================
 
-AppImages based on `Electron <https://www.electron.build/>`__ require the kernel to be configured in a certain way to allow for its sandboxing to work as intended (specifically, the kernel needs to be allowed to provide "unprivileged namespaces"). Many distributions come with this configured out of the box (like `Ubuntu <https://ubuntu.com>`__ for instance), but some do not (for example `Debian <https://debian.org>`__).
+AppImages based on `Electron <https://www.electron.build/>`__ require the kernel to be configured in a certain way to allow for its sandboxing to work as intended (specifically, the kernel needs to be allowed to provide "unprivileged namespaces"). Many distributions come with this configured out of the box (like `Ubuntu <https://ubuntu.com>`__ prior to `24.04 <https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890#unprivileged-user-namespace-restrictions-15>`__), but some do not (for example `Debian <https://debian.org>`__).
 
 .. warning::
 


### PR DESCRIPTION
starting in Ubuntu 23.10, and officially in 24.04, userns is disable in Ubuntu. Add information about userns working prior to 24.04 and linking to the Ubuntu release notes explaining userns and workarounds